### PR TITLE
update bignum dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Kevin Fitzgerald",
   "license": "MIT",
   "dependencies": {
-    "bignum": "^0.11.0"
+    "bignum": "^0.12.0"
   },
   "devDependencies": {
     "mocha": "^2.3.0",


### PR DESCRIPTION
updating to latest bignum dependency, there are issues when building base-id on new MacOS Sierra  10.12.1